### PR TITLE
Correct FROM entry in Dockerfile.ocp

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-base-openshift-4.8 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-base-openshift-4.8
 
 ENV PKGS_LIST=packages-list.txt
 ARG EXTRA_PKGS_LIST
@@ -11,7 +11,7 @@ RUN prepare-image.sh && \
   mkdir -p /etc/ironic-python-agent && \
   rm -f /bin/prepare-image.sh
 
-COPY hardware_manager /tmp/hardware_manager
+COPY hardware_manager /tmp/
 
 RUN PBR_VERSION=1.0 pip3 install --no-index --verbose --prefix=/usr /tmp/hardware_manager
 


### PR DESCRIPTION
The AS in the FROM instruction generates a multi layered image that is
not reused anywhere in the Dockerfile, it's not needed and it prevents
the correct build of the final container image.

Also copying hardware_manager doesn't require filename destination.