### PR TITLE
Revert the COPY hardware_manager change

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN dnf install -y python3 python3-requests && \
     mkdir -p /etc/ironic-python-agent && \
     rm -f /bin/prepare-image.sh
 
-COPY hardware_manager /tmp/
+COPY hardware_manager /tmp/hardware_manager
 
 RUN PBR_VERSION=1.0 pip3 install --no-index --verbose --prefix=/usr /tmp/hardware_manager
 

--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -11,7 +11,7 @@ RUN prepare-image.sh && \
   mkdir -p /etc/ironic-python-agent && \
   rm -f /bin/prepare-image.sh
 
-COPY hardware_manager /tmp/
+COPY hardware_manager /tmp/hardware_manager
 
 RUN PBR_VERSION=1.0 pip3 install --no-index --verbose --prefix=/usr /tmp/hardware_manager
 


### PR DESCRIPTION
Image building fails after it with:

 pip.exceptions.InstallationError: Invalid requirement: '/tmp/hardware_manager'
 It looks like a path. Does it exist ?