### PR TITLE
Fix the default network config for the installed OS

### DIFF
--- a/hardware_manager/ironic_coreos_install.py
+++ b/hardware_manager/ironic_coreos_install.py
@@ -93,6 +93,12 @@ class CoreOSInstallHardwareManager(hardware.HardwareManager):
 
         copy_network = meta_data.get('coreos_copy_network', True)
         if copy_network:
+            try:
+                os.unlink(os.path.join(ROOT_MOUNT_PATH, 'etc',
+                                       'NetworkManager/system-connections',
+                                       'default_connection.nmconnection'))
+            except FileNotFoundError:
+                pass
             args += ['--copy-network']
 
         command = ['chroot', ROOT_MOUNT_PATH,

--- a/hardware_manager/ironic_coreos_install.py
+++ b/hardware_manager/ironic_coreos_install.py
@@ -12,6 +12,7 @@
 
 import json
 import os
+import shlex
 import subprocess
 
 from ironic_lib import disk_utils
@@ -85,6 +86,11 @@ class CoreOSInstallHardwareManager(hardware.HardwareManager):
         else:
             args += ['--offline']
 
+
+        ip_args = ','.join(_get_kernel_ip_args())
+        if ip_args:
+            args += ['--append-karg', ip_args]
+
         copy_network = meta_data.get('coreos_copy_network', True)
         if copy_network:
             args += ['--copy-network']
@@ -124,3 +130,15 @@ class CoreOSInstallHardwareManager(hardware.HardwareManager):
         except subprocess.CalledProcessError as exc:
             LOG.warning("coreos-installer failed: %s", exc)
             raise
+
+
+def _get_kernel_ip_args():
+    try:
+        with open(os.path.join(ROOT_MOUNT_PATH, 'proc/cmdline')) as f:
+            cmdline = f.read()
+
+        for arg in shlex.split(cmdline):
+            if arg.startswith('ip='):
+                yield arg
+    except OSError as exc:
+        LOG.warning('Failed to read kernel cmdline: %s', exc)


### PR DESCRIPTION
Get rid of the default config generated by NetworkManager during the IPA boot, since it currently limits us to DHCP on only one interface (the wrong one). This is a workaround for https://bugzilla.redhat.com/show_bug.cgi?id=2032717

Since the default config will not be persisted, we need to copy and `ip=dhcp`/`ip=dhcp6` kernel options passed to the IPA boot to the installed OS.