### PR TITLE
Bug 2038303: Allow customisation of default_connection file

### DIFF
--- a/hardware_manager/ironic_coreos_install.py
+++ b/hardware_manager/ironic_coreos_install.py
@@ -84,7 +84,8 @@ class CoreOSInstallHardwareManager(hardware.HardwareManager):
         if ip_args:
             args += ['--append-karg', ip_args]
 
-        copy_network = meta_data.get('coreos_copy_network', True)
+        copy_network = meta_data.get('coreos_copy_network',
+                os.getenv('IPA_COREOS_COPY_NETWORK', '').lower() == 'true')
         if copy_network:
             try:
                 os.unlink(os.path.join(ROOT_MOUNT_PATH, 'etc',

--- a/hardware_manager/ironic_coreos_install.py
+++ b/hardware_manager/ironic_coreos_install.py
@@ -87,12 +87,6 @@ class CoreOSInstallHardwareManager(hardware.HardwareManager):
         copy_network = meta_data.get('coreos_copy_network',
                 os.getenv('IPA_COREOS_COPY_NETWORK', '').lower() == 'true')
         if copy_network:
-            try:
-                os.unlink(os.path.join(ROOT_MOUNT_PATH, 'etc',
-                                       'NetworkManager/system-connections',
-                                       'default_connection.nmconnection'))
-            except FileNotFoundError:
-                pass
             args += ['--copy-network']
 
         command = ['chroot', ROOT_MOUNT_PATH,


### PR DESCRIPTION
If the user does not provide any network config, then a `default_connection.nmconnection` file created by network manager during early boot gets copied out of dracut. On PXE boots this file [limits us to using only the PXE interface](https://bugzilla.redhat.com/show_bug.cgi?id=2032717), which is something we don't want to do after installation.

To work around this, in #27 we started deleting the default connection before installing. However, this means that the user cannot supply a default connection either.

Instead, leave the default_connection file alone and only pass --copy-network if the user has provided a network config.