### PR TITLE
Bug 2053752: import time

### DIFF
--- a/hardware_manager/ironic_coreos_install.py
+++ b/hardware_manager/ironic_coreos_install.py
@@ -13,6 +13,7 @@
 import json
 import os
 import subprocess
+import time
 
 from ironic_lib import disk_utils
 from ironic_python_agent import efi_utils


### PR DESCRIPTION
This wasn't part of a recent cherry-pick as time
was already imported in origin/main but hadn't
been in release-4.10

We need to import it here