### PR TITLE
Bug 2098392: Include Fix discovering WWN/serial for devicemapper devices

### DIFF
--- a/packages-list.ocp
+++ b/packages-list.ocp
@@ -8,7 +8,7 @@ ipmitool
 lshw
 mdadm
 nvme-cli
-openstack-ironic-python-agent >= 8.6.1-0.20220602125411.d25f5be.el8
+openstack-ironic-python-agent >= 8.6.1-0.20220623075054.1d50c23.el8
 parted
 psmisc
 python3-dbus


### PR DESCRIPTION
The latest ipa package includes the change
https://review.opendev.org/c/openstack/ironic-python-agent/+/847155
that should be included in OCP 4.11