### PR TITLE
Bug 2100836: Add missing multipath modules

### DIFF
--- a/packages-list.ocp
+++ b/packages-list.ocp
@@ -1,4 +1,5 @@
 chrony
+device-mapper-multipath
 dosfstools
 efibootmgr
 efivar

--- a/packages-list.okd
+++ b/packages-list.okd
@@ -1,4 +1,5 @@
 chrony
+device-mapper-multipath
 dosfstools
 efibootmgr
 efivar


### PR DESCRIPTION
Multipath modules are missing therefore multipath configuration can't be
correctly activated.