### PR TITLE
Bug 2100775: Include Fix discovering WWN/serial for devicemapper devices

### DIFF
--- a/packages-list.ocp
+++ b/packages-list.ocp
@@ -8,7 +8,7 @@ ipmitool
 lshw
 mdadm
 nvme-cli
-openstack-ironic-python-agent >= 8.3.1-0.20220606104811.3c9b113.el8
+openstack-ironic-python-agent >= 8.3.1-0.20220628174045.c6ce477.el8
 parted
 psmisc
 python3-hardware-detect >= 0.29.0-0.20211122094056.7662a1d.el8


### PR DESCRIPTION
The latest ipa package includes the change
https://review.opendev.org/c/openstack/ironic-python-agent/+/847552
that should be included in OCP 4.10