### PR TITLE
Install iproute explicitely

### DIFF
--- a/packages-list.ocp
+++ b/packages-list.ocp
@@ -6,6 +6,7 @@ efivar
 gdisk
 hdparm
 ipmitool
+iproute
 lshw
 mdadm
 nvme-cli

--- a/packages-list.okd
+++ b/packages-list.okd
@@ -5,6 +5,7 @@ efibootmgr
 efivar
 gdisk
 ipmitool
+iproute
 hdparm
 lshw
 mdadm


### PR DESCRIPTION
It's not installed by default in rhel9