### PR TITLE
[release-4.10] OCPBUGS-1232: Include Fix for discovering bond interfaces

### DIFF
--- a/packages-list.ocp
+++ b/packages-list.ocp
@@ -9,7 +9,7 @@ ipmitool
 lshw
 mdadm
 nvme-cli
-openstack-ironic-python-agent >= 8.3.1-0.20220628174045.c6ce477.el8
+openstack-ironic-python-agent >= 8.3.1-0.20220809044411.1256849.el8
 parted
 psmisc
 python3-hardware-detect >= 0.29.0-0.20211122094056.7662a1d.el8


### PR DESCRIPTION
Upgrade to a IPA package that includes the change
https://review.opendev.org/c/openstack/ironic-python-agent/+/848867