### PR TITLE
"Bug OCPBUGS-15447: Switch to udevadm command install instead of package"

### DIFF
--- a/packages-list.ocp
+++ b/packages-list.ocp
@@ -18,5 +18,5 @@ python3-hardware-detect >= 0.30.0-0.20230308190813.f6ff0ed.el9
 python3-pip
 python3-werkzeug >= 2.0.3-4.el9
 qemu-img
-systemd-udev
+/usr/sbin/udevadm
 util-linux


### PR DESCRIPTION
The dnf command should be able to figure out the correct package needed for the udevadm command to be present.