### PR TITLE
METAL-913: drop dependency on python-hardware

### DIFF
--- a/ironic-python-agent.conf
+++ b/ironic-python-agent.conf
@@ -4,5 +4,5 @@ log_file = /var/log/ironic-python-agent.log
 use_stderr = True
 
 collect_lldp = True
-inspection_collectors = default,extra-hardware,logs
+inspection_collectors = default,logs
 inspection_dhcp_all_interfaces = True

--- a/packages-list.ocp
+++ b/packages-list.ocp
@@ -14,7 +14,6 @@ openstack-ironic-python-agent >= 9.8.1-0.20240118193516.ff113ed.el9
 parted
 psmisc
 python3-dbus
-python3-hardware-detect >= 0.31.0-0.20231214192627.af076d3.el9
 python3-pip
 python3-werkzeug >= 2.2.3-2.el9
 qemu-img

--- a/packages-list.okd
+++ b/packages-list.okd
@@ -14,7 +14,6 @@ openstack-ironic-python-agent
 parted
 psmisc
 python3-dbus
-python3-hardware-detect
 python3-pip
 qemu-img
 util-linux


### PR DESCRIPTION
Not used in BMO since https://github.com/metal3-io/baremetal-operator/pull/1297.