### PR TITLE
TRT-1637: Revert #128 "OCPBUGS-31549: update ironic-python-agent with latest fixes"

### DIFF
--- a/requirements.cachito
+++ b/requirements.cachito
@@ -1,2 +1,2 @@
 ironic-lib @ git+https://github.com/openshift/openstack-ironic-lib@61ca0b756a1246b2dd0832ecb9610dcb21a76013
-ironic-python-agent @ git+https://github.com/openshift/openstack-ironic-python-agent@6a6aed763463baeeab2d7be483a7c0caf75c8c0b
+ironic-python-agent @ git+https://github.com/openshift/openstack-ironic-python-agent@5d413015290eb5f1114890b3849428c33904e1be


### PR DESCRIPTION

Reverts #128 ; tracked by [TRT-1637](https://issues.redhat.com//browse/TRT-1637)

Per [OpenShift policy](https://github.com/openshift/enhancements/blob/master/enhancements/release/improving-ci-signal.md#quick-revert), we are reverting this breaking change to get CI and/or nightly payloads flowing again.

Test revert only, we don't know if this is our issue yet, but some metal jobs now are losing apiserver during install.

To unrevert this, revert this PR, and layer an additional separate commit on top that addresses the problem. Before merging the unrevert, please run these jobs on the PR and check the result of these jobs to confirm the fix has corrected the problem:

```
/payload-job periodic-ci-openshift-release-master-nightly-4.16-e2e-metal-ipi-ovn-ipv6
```

CC: @tdomnesc

<div align="right">
PR created by <a href="https://github.com/stbenjam/revertomatic">Revertomatic<sup>:tm:</sup></a>
</div>
