### PR TITLE
OCPBUGS-35968: Disable installation of .pyc files through pip

### DIFF
--- a/prepare-image.sh
+++ b/prepare-image.sh
@@ -38,15 +38,17 @@ if  [[ -f /tmp/packages-list.ocp ]]; then
     # NOTE(elfosardo): --no-index is used to install the packages emulating
     # an isolated environment in CI. Do not use the option for downstream
     # builds.
-    PIP_OPTIONS=""
+    # NOTE(janders): adding --no-compile option to avoid issues in FIPS
+    # enabled environments. See https://issues.redhat.com/browse/RHEL-29028
+    # for more information
+    PIP_OPTIONS="--no-compile"
     if [[ ! -d "${REMOTE_SOURCES_DIR}/cachito-gomod-with-deps" ]]; then
-        PIP_OPTIONS="--no-index"
+        PIP_OPTIONS="$PIP_OPTIONS --no-index"
     fi
     python3 -m pip install $PIP_OPTIONS --prefix /usr -r "${REQS}"
-
-    # ironic-python-agent system configuration
-
-    #
+    # NOTE(janders) since we set --no-compile at install time, we need to
+    # compile post-install (see RHEL-29028)
+    python3 -m compileall --invalidation-mode=timestamp /usr
 
     dnf remove -y $BUILD_DEPS
 


### PR DESCRIPTION
Installing compiled python files through pip can cause issues in FIPS-enabled environments. This change disables installing those files through pip and compiles them locally instead.