### PR TITLE
METAL-1049: Download and install sources from local dir

### DIFF
--- a/prepare-image.sh
+++ b/prepare-image.sh
@@ -45,12 +45,26 @@ if  [[ -f /tmp/packages-list.ocp ]]; then
     if [[ ! -d "${REMOTE_SOURCES_DIR}/cachito-gomod-with-deps" ]]; then
         PIP_OPTIONS="$PIP_OPTIONS --no-index"
     fi
-    python3 -m pip install $PIP_OPTIONS --prefix /usr -r "${REQS}"
+
+    # NOTE(elfosardo): download all the libraries and dependencies first, removing
+    # --no-index but using --no-deps to avoid chain-downloading packages.
+    # This forces to download only the packages specified in the requirements file,
+    # but we leave the --no-index in the installation phase to again avoid
+    # downloading unexpected packages and install only the downloaded ones.
+    # This is done to allow testing any source code package in CI emulating
+    # the cachito downstream build pipeline.
+    # See https://issues.redhat.com/browse/METAL-1049 for more details.
+    PIP_SOURCES_DIR="all_sources"
+    mkdir $PIP_SOURCES_DIR
+    python3 -m pip download --no-deps -r "${REQS}" -d $PIP_SOURCES_DIR
+    python3 -m pip install $PIP_OPTIONS --prefix /usr -r "${REQS}" -f $PIP_SOURCES_DIR
+
     # NOTE(janders) since we set --no-compile at install time, we need to
     # compile post-install (see RHEL-29028)
     python3 -m compileall --invalidation-mode=timestamp /usr
 
     dnf remove -y $BUILD_DEPS
+    rm -fr $PIP_SOURCES_DIR
 
     if [[ -d "${REMOTE_SOURCES_DIR}/cachito-gomod-with-deps" ]]; then
         rm -rf $REMOTE_SOURCES_DIR

--- a/requirements.cachito
+++ b/requirements.cachito
@@ -1,2 +1,4 @@
 ironic-lib @ git+https://github.com/openshift/openstack-ironic-lib@b5f03a528d4710194a84d6876a994ad1b0bcec03
 ironic-python-agent @ git+https://github.com/openshift/openstack-ironic-python-agent@2b880802d963e6a27c13b9cb07844255bebbccf6
+
+# DEPENDENCIES


### PR DESCRIPTION
Since in CI we use the --no-index option to emulate a pip disconnected environment to try and reproduce the downstream build conditions, it's not possible to test normal dependencies from source as pip won't be able to retrieve them from any remote source.
To work around that we download all the packages first removing the --no-index option but using the --no-deps option, preventing downloading dependencies.
This forces to download only the packages specified in the requirements file, ensuring total control on main libraries and dependencies and allowing us to be as granular as needed, easily switching between RPMs and source packages for testing or even for downstream builds.
When we install them afterwards if any dependency is missing the installation process will fail in CI, allowing us to correct the dependencies list directly the change PR.

Downloading the libraries first and then installing them with the same option allows more flexibility and almost a 1-to-1 copy of the downstream build environment that cachito uses.