### PR TITLE
OCPBUGS-38481: Update root image

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-8-release-golang-1.17-openshift-4.10
+  tag: rhel-9-release-golang-1.22-openshift-4.17


### PR DESCRIPTION
we should update it to avoid errors in the pipeline as the current one is too old.