### PR TITLE
[4.17] OCPBUGS-38511: set webob and bump werkzeug

### DIFF
--- a/packages-list.ocp
+++ b/packages-list.ocp
@@ -25,7 +25,8 @@ python3-psutil
 python3-pyudev
 python3-tenacity
 python3-tooz >= 6.2.0-0.20240708131954.c65282f.el9
-python3-werkzeug >= 2.2.3-2.el9
+python3-webob >= 1.8.8-2.el9
+python3-werkzeug >= 2.2.3-3.el9
 python3-zeroconf >= 0.24.4-2.el9
 qemu-img
 /usr/sbin/udevadm


### PR DESCRIPTION
This commit bumps the werkzeug to the same version of ironic-image. Adding python3-webob min version to be used.