### PR TITLE
[4.14] OCPBUGS-33375: set webob and bump werkzeug

### DIFF
--- a/packages-list.ocp
+++ b/packages-list.ocp
@@ -26,8 +26,8 @@ python3-psutil
 python3-pyudev
 python3-tenacity
 python3-tooz
-python3-webob
-python3-werkzeug >= 2.2.3-2.el9
+python3-webob >= 1.8.8-2.el9
+python3-werkzeug >= 2.2.3-3.el9
 python3-zeroconf
 qemu-img
 util-linux


### PR DESCRIPTION
This commit bumps the werkzeug to the same version of ironic-image. Adding python3-webob min version to be used.