### PR TITLE
[4.12] OCPBUGS-38513: set webob and bump werkzeug

### DIFF
--- a/packages-list.ocp
+++ b/packages-list.ocp
@@ -16,7 +16,8 @@ psmisc
 python3-dbus
 python3-hardware-detect >= 0.29.1-0.20220811165930.fd4bce6.el9
 python3-pip
-python3-werkzeug >= 2.0.3-4.el9
+python3-webob >= 1.8.8-2.el9
+python3-werkzeug >= 2.0.3-6.el9
 qemu-img
 /usr/sbin/udevadm
 util-linux


### PR DESCRIPTION
This commit bumps the werkzeug to the same version of ironic-image. Adding python3-webob min version to be used.