### PR TITLE
METAL-1155: Update to latest ironic projects hash for OCP 4.18

### DIFF
--- a/hardware_manager/ironic_coreos_install.py
+++ b/hardware_manager/ironic_coreos_install.py
@@ -18,7 +18,7 @@ from urllib import parse as urlparse
 
 import dbus
 
-from ironic_lib import disk_utils
+from ironic_python_agent import disk_utils
 from ironic_python_agent import efi_utils
 from ironic_python_agent import errors
 from ironic_python_agent import hardware

--- a/packages-list.ocp
+++ b/packages-list.ocp
@@ -15,11 +15,11 @@ psmisc
 python3-bcrypt
 python3-dbus
 python3-eventlet
-python3-netifaces
 python3-oslo-concurrency >= 6.0.0-0.20240522165021.53709ba.el9
 python3-oslo-config >= 9.4.0-0.20240522154012.882adf8.el9
 python3-oslo-log >= 6.0.0-0.20240708125539.f05a852.el9
 python3-oslo-service >= 3.5.0-0.20240708131154.a84a9de.el9
+python3-pbr >= 6.0.0-1.el9
 python3-pint
 python3-psutil
 python3-pyudev

--- a/prepare-image.sh
+++ b/prepare-image.sh
@@ -31,9 +31,12 @@ if  [[ -f /tmp/packages-list.ocp ]]; then
     fi
 
     ### source install ###
-    BUILD_DEPS="git python3-devel gcc gcc-c++"
+    BUILD_DEPS="git python3-devel gcc gcc-c++ python3-wheel"
 
-    dnf install -y python3-pip python3-setuptools $BUILD_DEPS
+    # NOTE(elfosardo): wheel is needed because of pip "no-build-isolation" option
+    # setting installation of setuptoools here as we may want to remove it
+    # in teh future once the container build is done
+    dnf install -y python3-pip 'python3-setuptools >= 64.0.0' $BUILD_DEPS
 
     # NOTE(elfosardo): --no-index is used to install the packages emulating
     # an isolated environment in CI. Do not use the option for downstream
@@ -41,7 +44,12 @@ if  [[ -f /tmp/packages-list.ocp ]]; then
     # NOTE(janders): adding --no-compile option to avoid issues in FIPS
     # enabled environments. See https://issues.redhat.com/browse/RHEL-29028
     # for more information
-    PIP_OPTIONS="--no-compile"
+    # NOTE(elfosardo): --no-build-isolation is needed to allow build engine
+    # to use build tools already installed in the system, for our case
+    # setuptools and pbr, instead of installing them in the isolated
+    # pip environment. We may change this in the future and just use
+    # full isolated environment and source build dependencies.
+    PIP_OPTIONS="--no-compile --no-cache-dir --no-build-isolation"
     if [[ ! -d "${REMOTE_SOURCES_DIR}/cachito-gomod-with-deps" ]]; then
         PIP_OPTIONS="$PIP_OPTIONS --no-index"
     fi

--- a/requirements.cachito
+++ b/requirements.cachito
@@ -1,4 +1,4 @@
-ironic-lib @ git+https://github.com/openshift/openstack-ironic-lib@99f8a60b433bae56591fe90a34f03572d7f6eb2f
-ironic-python-agent @ git+https://github.com/openshift/openstack-ironic-python-agent@f5118693ea45551401223e542caf7168c75f749a
+ironic-lib @ git+https://github.com/openshift/openstack-ironic-lib@7045590c0aedba8dbdb43f0eb6c991575f75cbf8
+ironic-python-agent @ git+https://github.com/openshift/openstack-ironic-python-agent@49ce545d71d52f38c1d4b5e199b1ece9b61e1eaf
 
 # DEPENDENCIES


### PR DESCRIPTION
Latest IPA removes the netifaces dependency
Import disk_utils from IPA as it was moved a while ago
from ironic-lib