### PR TITLE
OCPBUGS-43546: Add ignition version number

### DIFF
--- a/hardware_manager/ironic_coreos_install.py
+++ b/hardware_manager/ironic_coreos_install.py
@@ -166,7 +166,8 @@ class CoreOSInstallHardwareManager(hardware.HardwareManager):
         if isinstance(ignition, str):
             ignition = json.loads(ignition)
         elif not ignition:
-            ignition = {}
+            ignition = {"ignition":{"version":"3.0.0"}}
+
 
         encoded = urlparse.quote(self._firstboot_hostname)
 


### PR DESCRIPTION
When no other ignition exists we need to create it from scratch with a version number.