### PR TITLE
METAL-1302: Do not use openstack packages

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -12,7 +12,8 @@ COPY prepare-image.sh patch-image.sh /bin/
 # some cachito magic
 COPY "$REMOTE_SOURCES" "$REMOTE_SOURCES_DIR"
 
-RUN prepare-image.sh && \
+RUN dnf config-manager --disable rhel-9-openstack-17-rpms  || true && \
+  prepare-image.sh && \
   mkdir -p /etc/ironic-python-agent && \
   rm -f /bin/prepare-image.sh
 


### PR DESCRIPTION
They conflict with our owns and we don't use them in production so the builds are completely different between CI and production actually making the tests completely unreliable.

(cherry picked from commit 5ca78f787310edac32746b8358e45b1028d81660)