### PR TITLE
METAL-1574: Update deps pkgs versions

### DIFF
--- a/packages-list.ocp
+++ b/packages-list.ocp
@@ -18,11 +18,12 @@ python3.12-charset-normalizer
 python3.12-cheroot >= 10.0.1-5.el9
 python3.12-dbus
 python3.12-eventlet >= 0.40.1-1.el9ocp
+python3.12-futurist >= 3.2.1-1
 python3.12-inotify >= 0.9.6-26.el9ocp
 python3.12-oslo-concurrency >= 7.1.0
 python3.12-oslo-config >= 9.7.1
 python3.12-oslo-log >= 7.1.0
-python3.12-oslo-service >= 4.1.1
+python3.12-oslo-service >= 4.3.0
 python3.12-pbr >= 6.0.0-1.el9
 python3.12-pint
 python3.12-psutil


### PR DESCRIPTION
This is to explicitely align with ironic-image dependencies