### PR TITLE
OCPBUGS-62441: netutils: Use ethtool ioctl to get permanent mac address

### DIFF
--- a/requirements.cachito
+++ b/requirements.cachito
@@ -1,3 +1,3 @@
-ironic-python-agent @ git+https://github.com/openshift/openstack-ironic-python-agent@01d3990d3ab1d32efc9a87b68c3290dc8e64cef9
+ironic-python-agent @ git+https://github.com/openshift/openstack-ironic-python-agent@b6f1e43c97fb9020cefeb17f288544a05ffb39c4
 
 # DEPENDENCIES


### PR DESCRIPTION
Use ethtool ioctl to get permanent MAC address in ironic-python-agent so that in case of bonded interfaces, the correct interface MAC addresses are reported
Backporting upstream fix into 4.19 by including https://github.com/openshift/openstack-ironic-python-agent/pull/147