### PR TITLE
OCPBUGS-61165: netutils: Use ethtool ioctl to get permanent mac address

### DIFF
--- a/requirements.cachito
+++ b/requirements.cachito
@@ -1,2 +1,2 @@
 ironic-lib @ git+https://github.com/openshift/openstack-ironic-lib@4c435d91ea767bbb251376a28f6eeacd09ae680b
-ironic-python-agent @ git+https://github.com/openshift/openstack-ironic-python-agent@b725b8a75579aaf36c84632eb80a4bafe3ce3d3b
+ironic-python-agent @ git+https://github.com/openshift/openstack-ironic-python-agent@25670b09e2a92749cf17465aa793be3445e83c97


### PR DESCRIPTION
Use ethtool ioctl to get permanent MAC address in ironic-python-agent so that in case of bonded interfaces, the correct interface MAC addresses are reported
Backporting upstream fix into 4.16 by including https://github.com/openshift/openstack-ironic-python-agent/pull/151