### PR TITLE
METAL-1779: Add podman package for bootc deploy

### DIFF
--- a/packages-list.ocp
+++ b/packages-list.ocp
@@ -12,6 +12,7 @@ lshw
 mdadm
 nvme-cli
 parted
+podman
 psmisc
 python3.12-bcrypt
 python3.12-charset-normalizer
@@ -34,4 +35,5 @@ python3.12-webob >= 1.8.8-2.el9
 python3.12-werkzeug >= 2.2.3-3.el9
 python3.12-zeroconf >= 0.24.4-2.el9
 qemu-img
+slirp4netns
 util-linux

--- a/packages-list.okd
+++ b/packages-list.okd
@@ -13,7 +13,9 @@ lshw
 mdadm
 nvme-cli
 parted
+podman
 psmisc
 qemu-img
+slirp4netns
 util-linux
 /usr/sbin/udevadm


### PR DESCRIPTION
The bootc deploy interface requires podman to run the bootc install with the provided container image [1]. This change adds the podman package.

[1] https://opendev.org/openstack/ironic-python-agent/src/branch/master/ironic_python_agent/extensions/standby.py#L1283-L1310