### PR TITLE
NO-ISSUE: Remove openstack repo workaround

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -14,10 +14,9 @@ COPY "$REMOTE_SOURCES" "$REMOTE_SOURCES_DIR"
 
 COPY hardware_manager /tmp/hardware_manager
 
-RUN dnf config-manager --disable rhel-9-openstack-17-rpms  || true && \
-  prepare-image.sh && \
-  mkdir -p /etc/ironic-python-agent && \
-  rm -f /bin/prepare-image.sh
+RUN prepare-image.sh && \
+    mkdir -p /etc/ironic-python-agent && \
+    rm -f /bin/prepare-image.sh
 
 COPY ironic-python-agent.conf /etc/ironic-python-agent/00-defaults.conf
 


### PR DESCRIPTION
This has been fixed in the official repo list

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined container image build configuration to optimize the image preparation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->