### PR TITLE
METAL-1838: Bump setuptools version to align with latest ironic requirements

### DIFF
--- a/packages-list.ocp
+++ b/packages-list.ocp
@@ -19,6 +19,8 @@ python3.12-charset-normalizer
 python3.12-cheroot >= 10.0.1-5.el9
 python3.12-dbus
 python3.12-eventlet >= 0.40.1-1.el9ocp
+python3.12-flexcache >= 0.3-3.el9ocp
+python3.12-flexparser >= 0.4-1.el9ocp
 python3.12-futurist >= 3.2.1-1
 python3.12-inotify >= 0.9.6-26.el9ocp
 python3.12-oslo-concurrency >= 7.1.0
@@ -26,7 +28,7 @@ python3.12-oslo-config >= 9.7.1
 python3.12-oslo-log >= 7.1.0
 python3.12-oslo-service >= 4.3.0
 python3.12-pbr >= 6.0.0-1.el9
-python3.12-pint
+python3.12-pint >= 0.24.4-2.el9ocp
 python3.12-psutil
 python3.12-pyudev >= 0.22.0-6.1.el9ocp
 python3.12-tenacity

--- a/prepare-image.sh
+++ b/prepare-image.sh
@@ -36,7 +36,7 @@ if  [[ -f /tmp/packages-list.ocp ]]; then
 
     # setting installation of setuptoools here as we may want to remove it
     # in the future once the container build is done
-    dnf install -y python3.12-pip 'python3.12-setuptools >= 70.3.0' $BUILD_DEPS
+    dnf install -y python3.12-pip 'python3.12-setuptools >= 78.1.1' $BUILD_DEPS
 
     # NOTE(elfosardo): --no-index is used to install the packages emulating
     # an isolated environment in CI. Do not use the option for downstream


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Raised the minimum required version for Python setuptools to a newer release.
  * Added new Python packages: python3.12-flexcache and python3.12-flexparser with minimum version constraints.
  * Tightened python3.12-pint to require version >= 0.24.4-2.el9ocp.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->