### PR TITLE
METAL-1865: Extract OCP build deps to build-packages-list.ocp

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -6,7 +6,7 @@ ENV PKGS_LIST=packages-list.ocp
 ARG EXTRA_PKGS_LIST
 ARG PATCH_LIST
 
-COPY ${PKGS_LIST}* ${EXTRA_PKGS_LIST:-$PKGS_LIST} ${PATCH_LIST:-$PKGS_LIST} /tmp/
+COPY ${PKGS_LIST}* build-packages-list.ocp ${EXTRA_PKGS_LIST:-$PKGS_LIST} ${PATCH_LIST:-$PKGS_LIST} /tmp/
 COPY prepare-image.sh patch-image.sh setup.okd /bin/
 
 # some cachito magic

--- a/build-packages-list.ocp
+++ b/build-packages-list.ocp
@@ -1,0 +1,5 @@
+gcc
+gcc-c++
+python3.12-devel
+python3.12-pip
+python3.12-setuptools >= 78.1.1

--- a/prepare-image.sh
+++ b/prepare-image.sh
@@ -32,11 +32,7 @@ if  [[ -f /tmp/packages-list.ocp ]]; then
     fi
 
     ### source install ###
-    BUILD_DEPS="python3.12-devel gcc gcc-c++"
-
-    # setting installation of setuptoools here as we may want to remove it
-    # in the future once the container build is done
-    dnf install -y python3.12-pip 'python3.12-setuptools >= 78.1.1' $BUILD_DEPS
+    grep -vE '^(#|$)' /tmp/build-packages-list.ocp | xargs -rtd'\n' dnf install -y
 
     # NOTE(elfosardo): --no-index is used to install the packages emulating
     # an isolated environment in CI. Do not use the option for downstream
@@ -73,7 +69,6 @@ if  [[ -f /tmp/packages-list.ocp ]]; then
 
     PBR_VERSION=1.0 python3.12 -m pip install --no-build-isolation --no-index --verbose --prefix=/usr /tmp/hardware_manager
 
-    dnf remove -y $BUILD_DEPS
     rm -fr $PIP_SOURCES_DIR
 
     if [[ -d "${REMOTE_SOURCES_DIR}/cachito-gomod-with-deps" ]]; then


### PR DESCRIPTION
Move the DNF build dependencies from inline prepare-image.sh to a dedicated build-packages-list.ocp file, ensuring changes trigger CI prevalidation jobs. Remove the BUILD_DEPS install/remove pattern in preparation for a multi-stage build split.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Docker image build process refactored to dynamically load build dependencies from external configuration files instead of hardcoded specifications, improving flexibility and maintainability. Build requirements including compiler tools and Python development packages are now managed through external configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->