### PR TITLE
METAL-1870: Split OCP build into multi-stage with wheel-builder

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,21 +1,42 @@
-FROM registry.ci.openshift.org/ocp/5.0:base-rhel9
+## Build Python wheels from cachito sources
+FROM registry.ci.openshift.org/ocp/5.0:base-rhel9 AS wheel-builder
 
 ENV REMOTE_SOURCES=${REMOTE_SOURCES:-"requirements*.cachito"}
 ENV REMOTE_SOURCES_DIR=${REMOTE_SOURCES_DIR:-"/remote_sources_dir/"}
-ENV PKGS_LIST=packages-list.ocp
-ARG EXTRA_PKGS_LIST
-ARG PATCH_LIST
 
-COPY ${PKGS_LIST}* build-packages-list.ocp ${EXTRA_PKGS_LIST:-$PKGS_LIST} ${PATCH_LIST:-$PKGS_LIST} /tmp/
-COPY prepare-image.sh patch-image.sh setup.okd /bin/
+COPY build-packages-list.ocp /tmp/
 
-# some cachito magic
+# Install build dependencies
+RUN set -euxo pipefail && \
+    echo "install_weak_deps=False" >> /etc/dnf/dnf.conf && \
+    echo "tsflags=nodocs" >> /etc/dnf/dnf.conf && \
+    xargs -rtd'\n' dnf install -y < /tmp/build-packages-list.ocp
+
+# Copy cachito sources
 COPY "$REMOTE_SOURCES" "$REMOTE_SOURCES_DIR"
 
 COPY hardware_manager /tmp/hardware_manager
 
-RUN prepare-image.sh && \
-    mkdir -p /etc/ironic-python-agent && \
+# Build wheels from cachito requirements and hardware_manager
+COPY build-wheels-ocp.sh /bin/
+
+RUN set -euxo pipefail && \
+    build-wheels-ocp.sh
+
+# build final image
+FROM registry.ci.openshift.org/ocp/5.0:base-rhel9
+
+ENV PKGS_LIST=packages-list.ocp
+ARG EXTRA_PKGS_LIST
+ARG PATCH_LIST
+
+COPY ${PKGS_LIST}* ${EXTRA_PKGS_LIST:-$PKGS_LIST} ${PATCH_LIST:-$PKGS_LIST} /tmp/
+COPY prepare-image.sh patch-image.sh setup.okd /bin/
+
+# Install Python packages from pre-built wheels (mounted from wheel-builder stage)
+RUN --mount=from=wheel-builder,source=/wheels,target=/wheels \
+    set -euxo pipefail && \
+    prepare-image.sh && \
     rm -f /bin/prepare-image.sh
 
 COPY ironic-python-agent.conf /etc/ironic-python-agent/00-defaults.conf

--- a/build-packages-list.ocp
+++ b/build-packages-list.ocp
@@ -1,5 +1,9 @@
 gcc
 gcc-c++
 python3.12-devel
+python3.12-packaging >= 24.2
+python3.12-pbr
 python3.12-pip
 python3.12-setuptools >= 78.1.1
+python3.12-setuptools_scm
+python3.12-wheel

--- a/build-wheels-ocp.sh
+++ b/build-wheels-ocp.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/bash
+
+# This script builds Python wheels from cachito sources for the OCP build.
+# It runs in the wheel-builder stage of the Docker build.
+# Adapted from ironic-image's build-wheels-ocp.sh with the addition of
+# the hardware_manager local package.
+
+set -euxo pipefail
+
+REQS="${REMOTE_SOURCES_DIR}/requirements.cachito"
+
+# load cachito variables only if they're available
+if [[ -d "${REMOTE_SOURCES_DIR}/cachito-gomod-with-deps" ]]; then
+    source "${REMOTE_SOURCES_DIR}/cachito-gomod-with-deps/cachito.env"
+    REQS="${REMOTE_SOURCES_DIR}/cachito-gomod-with-deps/app/requirements.cachito"
+fi
+
+# NOTE(elfosardo): --no-build-isolation is needed to allow build engine
+# to use build tools already installed in the system, for our case
+# setuptools and pbr, instead of installing them in the isolated
+# pip environment.
+WHEEL_OPTIONS="--no-cache-dir --no-build-isolation --no-index"
+
+# NOTE(elfosardo): download all the libraries and dependencies first,
+# using --no-deps to avoid chain-downloading packages.
+# This forces to download only the packages specified in the requirements file.
+# This is done to allow testing any source code package in CI emulating
+# the cachito downstream build pipeline.
+# See https://issues.redhat.com/browse/METAL-1049 for more details.
+PIP_SOURCES_DIR="/tmp/all_sources"
+mkdir -p "${PIP_SOURCES_DIR}"
+python3.12 -m pip download --no-binary=:all: --no-build-isolation --no-deps -r "${REQS}" -d "${PIP_SOURCES_DIR}"
+
+# Build wheels from downloaded sources
+mkdir -p /wheels
+# shellcheck disable=SC2086
+python3.12 -m pip wheel \
+    $WHEEL_OPTIONS \
+    --wheel-dir=/wheels \
+    --no-deps \
+    --find-links="${PIP_SOURCES_DIR}" \
+    -r "${REQS}"
+
+# Build the hardware_manager local package
+PBR_VERSION=1.0 python3.12 -m pip wheel \
+    --no-build-isolation \
+    --no-index \
+    --no-deps \
+    --wheel-dir=/wheels \
+    /tmp/hardware_manager
+
+rm -rf "${PIP_SOURCES_DIR}"
+
+echo "Wheels built successfully in /wheels"
+ls -la /wheels/

--- a/prepare-image.sh
+++ b/prepare-image.sh
@@ -18,62 +18,25 @@ if [[ ! -z ${EXTRA_PKGS_LIST:-} ]]; then
     fi
 fi
 
-### cachito magic works for OCP only
-if  [[ -f /tmp/packages-list.ocp ]]; then
+### OCP: Install from pre-built wheels (built in wheel-builder stage)
+if [[ -f /tmp/packages-list.ocp ]]; then
 
-    REQS="${REMOTE_SOURCES_DIR}/requirements.cachito"
+    dnf install -y python3.12-pip
 
-    ls -la "${REMOTE_SOURCES_DIR}/" # DEBUG
-
-    # load cachito variables only if they're available
-    if [[ -d "${REMOTE_SOURCES_DIR}/cachito-gomod-with-deps" ]]; then
-        source "${REMOTE_SOURCES_DIR}/cachito-gomod-with-deps/cachito.env"
-        REQS="${REMOTE_SOURCES_DIR}/cachito-gomod-with-deps/app/requirements.cachito"
-    fi
-
-    ### source install ###
-    grep -vE '^(#|$)' /tmp/build-packages-list.ocp | xargs -rtd'\n' dnf install -y
-
-    # NOTE(elfosardo): --no-index is used to install the packages emulating
-    # an isolated environment in CI. Do not use the option for downstream
-    # builds.
     # NOTE(janders): adding --no-compile option to avoid issues in FIPS
     # enabled environments. See https://issues.redhat.com/browse/RHEL-29028
     # for more information
-    # NOTE(elfosardo): --no-build-isolation is needed to allow build engine
-    # to use build tools already installed in the system, for our case
-    # setuptools and pbr, instead of installing them in the isolated
-    # pip environment. We may change this in the future and just use
-    # full isolated environment and source build dependencies.
-    PIP_OPTIONS="--no-compile --no-cache-dir --no-build-isolation"
-    if [[ ! -d "${REMOTE_SOURCES_DIR}/cachito-gomod-with-deps" ]]; then
-        PIP_OPTIONS="$PIP_OPTIONS --no-index"
-    fi
-
-    # NOTE(elfosardo): download all the libraries and dependencies first, removing
-    # --no-index but using --no-deps to avoid chain-downloading packages.
-    # This forces to download only the packages specified in the requirements file,
-    # but we leave the --no-index in the installation phase to again avoid
-    # downloading unexpected packages and install only the downloaded ones.
-    # This is done to allow testing any source code package in CI emulating
-    # the cachito downstream build pipeline.
-    # See https://issues.redhat.com/browse/METAL-1049 for more details.
-    PIP_SOURCES_DIR="all_sources"
-    mkdir $PIP_SOURCES_DIR
-    python3.12 -m pip download --no-binary=:all: --no-build-isolation --no-deps -r "${REQS}" -d $PIP_SOURCES_DIR
-    python3.12 -m pip install $PIP_OPTIONS --prefix /usr -r "${REQS}" -f $PIP_SOURCES_DIR
+    python3.12 -m pip install \
+        --no-compile \
+        --no-cache-dir \
+        --no-index \
+        --find-links=/wheels \
+        --prefix /usr \
+        /wheels/*.whl
 
     # NOTE(janders) since we set --no-compile at install time, we need to
     # compile post-install (see RHEL-29028)
     python3.12 -m compileall --invalidation-mode=timestamp -q -x '/usr/share/doc' /usr
-
-    PBR_VERSION=1.0 python3.12 -m pip install --no-build-isolation --no-index --verbose --prefix=/usr /tmp/hardware_manager
-
-    rm -fr $PIP_SOURCES_DIR
-
-    if [[ -d "${REMOTE_SOURCES_DIR}/cachito-gomod-with-deps" ]]; then
-        rm -rf $REMOTE_SOURCES_DIR
-    fi
 
 fi
 ###
@@ -90,6 +53,11 @@ if [[ ! -z ${PATCH_LIST:-} ]]; then
     fi
 fi
 rm -f /bin/patch-image.sh
+
+# pip is only needed at build time, remove it to reduce image size
+if [[ -f /tmp/packages-list.ocp ]]; then
+    dnf remove -y python3.12-pip
+fi
 
 # No subscriptions are required (or possible) in this container.
 rpm -q subscription-manager && \


### PR DESCRIPTION
Add a wheel-builder stage to Dockerfile.ocp that builds all Python wheels from cachito sources and the hardware_manager package. The final image installs only pre-built wheels via --mount, removing build dependencies (gcc, python3.12-devel, etc.) from the final image.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched container builds to a multi-stage process that precompiles and consumes Python wheel artifacts.
  * Added a dedicated wheel-building script for OCP builds from Cachito-sourced requirements.
  * Expanded the OCP Python 3.12 packaging dependency set (packaging/build tooling, wheel support).

* **Refactor**
  * Updated image preparation for OCP to install from prebuilt wheels instead of fetching/building sources at image time.
  * Reduced image size by removing temporary Python tooling after wheel installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->