### PR TITLE
OCPBUGS-94115: Replace dnf remove with rpm -e to prevent dependency removal

### DIFF
--- a/prepare-image.sh
+++ b/prepare-image.sh
@@ -54,14 +54,14 @@ if [[ ! -z ${PATCH_LIST:-} ]]; then
 fi
 rm -f /bin/patch-image.sh
 
-# pip is only needed at build time, remove it to reduce image size
+# Use rpm -e instead of dnf remove to avoid autoremove of dependencies
+# (microdnf can silently remove packages like iproute and psmisc)
 if [[ -f /tmp/packages-list.ocp ]]; then
-    dnf remove -y python3.12-pip
+    rpm -e --nodeps python3.12-pip
 fi
 
-# No subscriptions are required (or possible) in this container.
 rpm -q subscription-manager && \
-    dnf remove -y subscription-manager dnf-plugin-subscription-manager || true
+    rpm -e --nodeps subscription-manager dnf-plugin-subscription-manager || true
 
 # Pbr pulls in Git (30+ MiB), but actually only uses it in development context.
 rpm -q git-core && rpm -e --nodeps git-core || true


### PR DESCRIPTION
dnf remove (microdnf) implicitly autoremoves packages that were pulled
in as auto-dependencies during dnf upgrade, even if they are explicitly
listed in packages-list.ocp. This caused iproute and psmisc to be
silently removed from the ironic-agent container, leaving IPA without
the ip command and preventing it from heartbeating to Ironic (resulting
in cleaning timeouts).

rpm -e only removes the named packages with no autoremove behavior,
matching the existing pattern used for git-core.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the image preparation cleanup to use a safer package removal approach, reducing the chance of unintentionally removing critical system utilities during the cleanup phase.
  * Ensures selected packages are cleaned up correctly while preserving the necessary tooling for later steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->