### PR TITLE
OCPBUGS-95067: Replace dnf remove with rpm -e to prevent dependency removal

### DIFF
--- a/prepare-image.sh
+++ b/prepare-image.sh
@@ -63,7 +63,7 @@ if  [[ -f /tmp/packages-list.ocp ]]; then
     # compile post-install (see RHEL-29028)
     python3 -m compileall --invalidation-mode=timestamp /usr
 
-    dnf remove -y $BUILD_DEPS
+    rpm -e --nodeps $BUILD_DEPS
     rm -fr $PIP_SOURCES_DIR
 
     if [[ -d "${REMOTE_SOURCES_DIR}/cachito-gomod-with-deps" ]]; then
@@ -82,7 +82,7 @@ rm -f /bin/patch-image.sh
 
 # No subscriptions are required (or possible) in this container.
 rpm -q subscription-manager && \
-    dnf remove -y subscription-manager dnf-plugin-subscription-manager || true
+    rpm -e --nodeps subscription-manager dnf-plugin-subscription-manager || true
 
 # Pbr pulls in Git (30+ MiB), but actually only uses it in development context.
 rpm -q git-core && rpm -e --nodeps git-core || true


### PR DESCRIPTION
dnf remove (microdnf) implicitly autoremoves packages that were pulled in as auto-dependencies during dnf upgrade, even if they are explicitly listed in packages-list.ocp. This caused iproute and psmisc to be silently removed from the ironic-agent container, leaving IPA without the ip command and preventing it from heartbeating to Ironic (resulting in cleaning timeouts).

rpm -e only removes the named packages with no autoremove behavior, matching the existing pattern used for git-core.