### PR TITLE
OCPBUGS-96901: Replace individual package removal with a single rpm -e loop

### DIFF
--- a/prepare-image.sh
+++ b/prepare-image.sh
@@ -48,7 +48,7 @@ if  [[ -f /tmp/packages-list.ocp ]]; then
 
     #
 
-    dnf remove -y $BUILD_DEPS
+    rpm -e --nodeps $BUILD_DEPS
 
     if [[ -d "${REMOTE_SOURCES_DIR}/cachito-gomod-with-deps" ]]; then
         rm -rf $REMOTE_SOURCES_DIR
@@ -64,12 +64,11 @@ if [[ ! -z ${PATCH_LIST:-} ]]; then
 fi
 rm -f /bin/patch-image.sh
 
-# No subscriptions are required (or possible) in this container.
-rpm -q subscription-manager && \
-    dnf remove -y subscription-manager dnf-plugin-subscription-manager || true
-
-# Pbr pulls in Git (30+ MiB), but actually only uses it in development context.
-rpm -q git-core && rpm -e --nodeps git-core || true
+# Remove build-only and unnecessary packages; rpm -e is used instead of
+# dnf remove to avoid autoremove of dependencies.
+for pkg in subscription-manager dnf-plugin-subscription-manager git-core; do
+    rpm -e --nodeps "${pkg}" || true
+done
 
 dnf clean all
 rm -rf /var/cache/{yum,dnf}/*


### PR DESCRIPTION
dnf remove (microdnf) implicitly autoremoves packages pulled in as
auto-dependencies during dnf upgrade, which caused iproute and psmisc
to be silently removed from the ironic-agent container.

A single rpm -e invocation with multiple packages fails entirely if any
one is missing. Use a loop with || true so each package is handled
independently, eliminating the need for rpm -q guards and conditionals.