### PR TITLE
OCPBUGS-96903: Replace individual package removal with a single rpm -e loop

### DIFF
--- a/prepare-image.sh
+++ b/prepare-image.sh
@@ -24,12 +24,11 @@ if [[ ! -z ${PATCH_LIST:-} ]]; then
 fi
 rm -f /bin/patch-image.sh
 
-# No subscriptions are required (or possible) in this container.
-rpm -q subscription-manager && \
-    dnf remove -y subscription-manager dnf-plugin-subscription-manager || true
-
-# Pbr pulls in Git (30+ MiB), but actually only uses it in development context.
-rpm -q git-core && rpm -e --nodeps git-core || true
+# Remove build-only and unnecessary packages; rpm -e is used instead of
+# dnf remove to avoid autoremove of dependencies.
+for pkg in subscription-manager dnf-plugin-subscription-manager git-core; do
+    rpm -e --nodeps "${pkg}" || true
+done
 
 dnf clean all
 rm -rf /var/cache/{yum,dnf}/*


### PR DESCRIPTION
The previous approach used a mix of conditional blocks and rpm -q guards
to remove build-only and unnecessary packages (subscription-manager,
dnf-plugin-subscription-manager, git-core).

Using rpm -e with multiple packages on one invocation meant that a
single missing package would cause the entire command to fail, silently
skipping removal of the others.

A simple loop with || true handles each package independently and
eliminates the need for rpm -q pre-checks and OCP-specific conditionals.