### PR TITLE
METAL-1879: [s2i] Move direct dependencies from packages to source

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -10,7 +10,7 @@ COPY build-packages-list.ocp /tmp/
 RUN set -euxo pipefail && \
     echo "install_weak_deps=False" >> /etc/dnf/dnf.conf && \
     echo "tsflags=nodocs" >> /etc/dnf/dnf.conf && \
-    xargs -rtd'\n' dnf install -y < /tmp/build-packages-list.ocp
+    grep -v '^#' /tmp/build-packages-list.ocp | xargs -rtd'\n' dnf install -y
 
 # Copy cachito sources
 COPY "$REMOTE_SOURCES" "$REMOTE_SOURCES_DIR"

--- a/build-packages-list.ocp
+++ b/build-packages-list.ocp
@@ -1,9 +1,24 @@
+# C/C++ compilers for building Python C extensions (psutil, greenlet, etc.)
 gcc
 gcc-c++
+# Python headers for building C extensions
 python3.12-devel
-python3.12-packaging >= 24.2
+# build backends required by various packages in requirements.cachito
+python3.12-flit-core
+python3.12-hatch-fancy-pypi-readme
+python3.12-hatch-vcs
+python3.12-hatchling >= 1.21.1-1.1.el9ocp
+python3.12-packaging >= 24.2-1.el9ocp
+# used by most OpenStack packages as their build system
 python3.12-pbr
+python3.12-poetry-core
+# pip and wheel for downloading and building wheels
 python3.12-pip
 python3.12-setuptools >= 78.1.1
+# needed by bcrypt 4.x to compile its Rust-based _bcrypt extension
+python3.12-setuptools-rust
 python3.12-setuptools_scm
+# test dependencies pulled in by some OpenStack packages at build time
+python3.12-testresources >= 2.0.1
+python3.12-testscenarios >= 0.5.0
 python3.12-wheel

--- a/packages-list.ocp
+++ b/packages-list.ocp
@@ -14,28 +14,35 @@ nvme-cli
 parted
 podman
 psmisc
-python3.12-bcrypt
+python3.12-certifi >= 2020.12.5-2.1.el9
 python3.12-charset-normalizer
-python3.12-cheroot >= 10.0.1-5.el9
+python3.12-cryptography >= 41.0.7
+python3.12-dateutil >= 2.7.0
 python3.12-dbus
+python3.12-debtcollector >= 3.0.0-0.20250214185317.0e6ce1c.el9
 python3.12-eventlet >= 0.40.1-1.el9ocp
-python3.12-flexcache >= 0.3-3.el9ocp
-python3.12-flexparser >= 0.4-1.el9ocp
-python3.12-futurist >= 3.2.1-1
+python3.12-fasteners >= 0.7.0
+python3.12-greenlet >= 0.4.15
 python3.12-inotify >= 0.9.6-26.el9ocp
-python3.12-oslo-concurrency >= 7.1.0
-python3.12-oslo-config >= 9.7.1
-python3.12-oslo-log >= 7.1.0
-python3.12-oslo-service >= 4.3.0
-python3.12-pbr >= 6.0.0-1.el9
+python3.12-iso8601 >= 2.1.0-1.el9ocp
+python3.12-jaraco-functools
+python3.12-markupsafe >= 2.1.1-4.el9
+python3.12-more-itertools >= 2.6
+python3.12-msgpack >= 0.6.2-2.el9
+python3.12-oslo-i18n >= 3.15.3
+python3.12-packaging >= 20.4
+python3.12-paste >= 3.5.0-3.el9.1
+python3.12-paste-deploy >= 2.0.1-5.el9
+python3.12-routes >= 2.3.1
 python3.12-pint >= 0.24.4-2.el9ocp
-python3.12-psutil
+python3.12-pyparsing >= 2.1.0
 python3.12-pyudev >= 0.22.0-6.1.el9ocp
-python3.12-tenacity
-python3.12-tooz >= 6.3.0-0.20240926164120.734acc4.el9
-python3.12-webob >= 1.8.8-2.el9
+python3.12-setproctitle >= 1.3.7-1
+python3.12-six >= 1.9.0
+python3.12-typing-extensions >= 4.12.2-2.el9
+python3.12-voluptuous >= 0.11.7-3.1.el9ocp
 python3.12-werkzeug >= 2.2.3-3.el9
-python3.12-zeroconf >= 0.24.4-2.el9
+python3.12-yappi >= 1.0
 qemu-img
 slirp4netns
 util-linux

--- a/requirements.cachito
+++ b/requirements.cachito
@@ -13,4 +13,32 @@
 
 ironic-python-agent @ git+https://github.com/openshift/openstack-ironic-python-agent@bd8b1437c5179ae783519438feedcfd01db641d1
 
-# DEPENDENCIES
+# DIRECT DEPENDENCIES
+bcrypt===4.3.0
+cheroot===11.0.0
+futurist===3.2.1
+netaddr===1.3.0
+oslo.concurrency===7.2.0
+oslo.config===10.1.0
+oslo.context===6.4.0
+oslo.log===7.2.1
+oslo.serialization===5.8.0
+oslo.service===4.4.1
+oslo.utils===9.2.0
+pbr===7.0.3
+psutil===7.2.2
+PyYAML===6.0.3
+requests===2.32.5
+rfc3986===2.0.0
+stevedore===5.6.0
+tenacity===9.1.2
+tooz===6.3.0
+WebOb===1.8.10
+zeroconf===0.147.1
+
+# TRANSITIVE DEPENDENCIES
+# This list should be kept as small as possible
+idna===3.10
+ifaddr===0.2.0
+tzdata===2025.2
+urllib3===2.3.0


### PR DESCRIPTION
This is to simplify packages management.
In the long run it will help a lot when switching Python version and base distribution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Build Improvements**
  * Improved container dependency installation by ignoring comment lines in package lists before installing build packages.
* **New Features**
  * Expanded build support with additional C/C++ build dependencies, more Python 3.12 build backends, and build-time test requirements.
* **Dependency Updates**
  * Refreshed the Python 3.12 package roster by removing several packages and tightening/updating version constraints.
  * Reorganized requirements into explicit, pinned **direct** and **transitive** dependency lists for more consistent handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->