### PR TITLE
[release-4.22] OCPBUGS-99897: Bump ironic-python-agent pinned commit for CVE-2026-66138

### DIFF
--- a/requirements.cachito
+++ b/requirements.cachito
@@ -1,3 +1,3 @@
-ironic-python-agent @ git+https://github.com/openshift/openstack-ironic-python-agent@ad83155d24a0fcd03106059ab9944e1ba3301e0c
+ironic-python-agent @ git+https://github.com/openshift/openstack-ironic-python-agent@33cf80b4967c338f2304df3c44d083c3c8f9f7cd
 
 # DEPENDENCIES


### PR DESCRIPTION
## Change
\`\`\`diff
-ironic-python-agent @ git+https://github.com/openshift/openstack-ironic-python-agent@3c600e2da58c8ea8167a7885cc7e9a22c769d7e3
+ironic-python-agent @ git+https://github.com/openshift/openstack-ironic-python-agent@33cf80b4967c338f2304df3c44d083c3c8f9f7cd \`\`\`

