### PR TITLE
[release-4.21] OCPBUGS-100051: Bump ironic-python-agent pinned commit for CVE-2026-66138

### DIFF
--- a/requirements.cachito
+++ b/requirements.cachito
@@ -1,3 +1,3 @@
-ironic-python-agent @ git+https://github.com/openshift/openstack-ironic-python-agent@9ab35b82f8b6e536fe3306ca2f4e2243228c049e
+ironic-python-agent @ git+https://github.com/openshift/openstack-ironic-python-agent@10b10f29eff0440fc6b68b13de346463977bd278
 
 # DEPENDENCIES


### PR DESCRIPTION
Update the pinned ironic-python-agent commit from e624ef77 to 295c9d27, which cherry-picks upstream security fix d4926bf9 (NTP command injection in sync_clock(), CVE-2026-66138) onto the OCP 4.21 branch of the openshift/openstack-ironic-python-agent fork.

Related: OCPBUGS-100051