### PR TITLE
METAL-1931: Add cargo for bcrypt rust extensions

### DIFF
--- a/build-packages-list.ocp
+++ b/build-packages-list.ocp
@@ -21,7 +21,8 @@ python3.12-pip
 python3.12-setuptools >= 78.1.1
 
 # needed by bcrypt 4.x to compile its Rust-based _bcrypt extension
-python3.12-setuptools-rust
+cargo
+python3.12-setuptools-rust >= 1.9.0
 python3.12-setuptools_scm
 
 # test dependencies pulled in by some OpenStack packages at build time


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added Cargo as a build dependency.
  * Updated the minimum supported version of setuptools-rust to 1.9.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->