### PR TITLE
[release-4.20] OCPBUGS-99887: Bump ironic-python-agent pinned commit for CVE-2026-66138

### DIFF
--- a/requirements.cachito
+++ b/requirements.cachito
@@ -1,3 +1,3 @@
-ironic-python-agent @ git+https://github.com/openshift/openstack-ironic-python-agent@33ff8172469058313c1e73eb93c2665006770666
+ironic-python-agent @ git+https://github.com/openshift/openstack-ironic-python-agent@90c176ab6ea232baa71e6ea821ca77280e551209
 
 # DEPENDENCIES


### PR DESCRIPTION
Bumps the pinned `ironic-python-agent` commit in `requirements.cachito` from `33ff8172` to `90c176ab` (current `release-4.20` tip), which includes the upstream security fix for CVE-2026-66138 (NTP command injection in `sync_clock()`), cherry-picked as `41f47d1b` onto the OCP 4.20 branch via openshift/openstack-ironic-python-agent#196 (merged), alongside the unrelated fix from openshift/openstack-ironic-python-agent#206.

Related: OCPBUGS-99887