### PR TITLE
[release-4.19] OCPBUGS-99885: Bump ironic-python-agent pinned commit for CVE-2026-66138

### DIFF
--- a/requirements.cachito
+++ b/requirements.cachito
@@ -1,3 +1,3 @@
-ironic-python-agent @ git+https://github.com/openshift/openstack-ironic-python-agent@53b7a3db69b8da57984ca8f00290ed9ddd0df8a5
+ironic-python-agent @ git+https://github.com/openshift/openstack-ironic-python-agent@0e1dc9a384d85e93cdc660648a3917eb7c81cdf2
 
 # DEPENDENCIES


### PR DESCRIPTION
Bumps the pinned `ironic-python-agent` commit in `requirements.cachito` from `53b7a3db` to `1d9584e6`, which cherry-picks the upstream security fix for CVE-2026-66138 (NTP command injection in `sync_clock()`) onto the OCP 4.19 branch via openshift/openstack-ironic-python-agent#197.

**Note:** openshift/openstack-ironic-python-agent#197 is not yet merged at the time this PR was opened (opened intentionally before merge, so both PRs stay linked to the Jira bug simultaneously). `ci/prow/check-requirements` is expected to fail/wait until #197 merges, at which point the pinned SHA here will be corrected to the real merge commit on `release-4.19`.

Related: OCPBUGS-99885