### PR TITLE
[release-4.18] OCPBUGS-99888: Bump ironic-python-agent pinned commit for CVE-2026-66138

### DIFF
--- a/requirements.cachito
+++ b/requirements.cachito
@@ -1,4 +1,4 @@
 ironic-lib @ git+https://github.com/openshift/openstack-ironic-lib@96ac462d0c3d53c70256cb048e42c317cc41b682
-ironic-python-agent @ git+https://github.com/openshift/openstack-ironic-python-agent@88c6e940f984b5c5290180732fc4bbbe6e777052
+ironic-python-agent @ git+https://github.com/openshift/openstack-ironic-python-agent@dd43c074e4ceb686d82733fbd9469cd71a73159e
 
 # DEPENDENCIES


### PR DESCRIPTION
Bumps the pinned `ironic-python-agent` commit in `requirements.cachito` from `88c6e940` to `dd43c074`, which cherry-picks the upstream security fix for CVE-2026-66138 (NTP command injection in `sync_clock()`) onto the OCP 4.18 branch via openshift/openstack-ironic-python-agent#198.

**Note:** openshift/openstack-ironic-python-agent#198 is not yet merged at the time this PR was opened (opened intentionally before merge, so both PRs stay linked to the Jira bug simultaneously). `ci/prow/check-requirements` is expected to fail/wait until #198 merges, at which point the pinned SHA here will be corrected to the real merge commit on `release-4.18`.

Related: OCPBUGS-99888