### PR TITLE
[release-4.17] OCPBUGS-99886: Bump ironic-python-agent pinned commit for CVE-2026-66138

### DIFF
--- a/requirements.cachito
+++ b/requirements.cachito
@@ -1,4 +1,4 @@
 ironic-lib @ git+https://github.com/openshift/openstack-ironic-lib@7578e8e32e3eb5e07da8806bc0a029e879dbb627
-ironic-python-agent @ git+https://github.com/openshift/openstack-ironic-python-agent@cc80173fd5dc620ad472626ee1ae71940070be35
+ironic-python-agent @ git+https://github.com/openshift/openstack-ironic-python-agent@746218d02412e33382f7d8e85f46ccbfd4cf7738
 
 # DEPENDENCIES


### PR DESCRIPTION
Bumps the pinned `ironic-python-agent` commit in `requirements.cachito` from `cc80173f` to `a6936c43`, which cherry-picks the upstream security fix for CVE-2026-66138 (NTP command injection in `sync_clock()`) onto the OCP 4.17 branch via openshift/openstack-ironic-python-agent#199.

**Note:** openshift/openstack-ironic-python-agent#199 is not yet merged at the time this PR was opened (opened intentionally before merge, so both PRs stay linked to the Jira bug simultaneously). `ci/prow/check-requirements` is expected to fail/wait until #199 merges, at which point the pinned SHA here will be corrected to the real merge commit on `release-4.17`.

Related: OCPBUGS-99886