### PR TITLE
[release-4.14] OCPBUGS-99891: Bump ironic-python-agent pinned commit for CVE-2026-66138

### DIFF
--- a/requirements.cachito
+++ b/requirements.cachito
@@ -1,2 +1,2 @@
 ironic-lib @ git+https://github.com/openshift/openstack-ironic-lib@6f6a0d7cab85358fbf94fd1e248ee220895deedd
-ironic-python-agent @ git+https://github.com/openshift/openstack-ironic-python-agent@231ed6f2b8d9c21987184feb11bfb991b647dcc7
+ironic-python-agent @ git+https://github.com/openshift/openstack-ironic-python-agent@1706b078e12177ee951d1e1b3dd57b1f300792c3


### PR DESCRIPTION
Bumps the pinned `ironic-python-agent` commit in `requirements.cachito` from `231ed6f2` to `1706b078`, which cherry-picks the upstream security fix for CVE-2026-66138 (NTP command injection in `sync_clock()`) onto the OCP 4.14 branch via openshift/openstack-ironic-python-agent#202.

**Note:** openshift/openstack-ironic-python-agent#202 is not yet merged at the time this PR was opened (opened intentionally before merge, so both PRs stay linked to the Jira bug simultaneously). `ci/prow/check-requirements` is expected to fail/wait until #202 merges, at which point the pinned SHA here will be corrected to the real merge commit on `release-4.14`.

Related: OCPBUGS-99891