### PR TITLE
[release-4.18] OCPBUGS-99888: Correct ironic-python-agent pin to include the CVE-2026-66138 fix

### DIFF
--- a/requirements.cachito
+++ b/requirements.cachito
@@ -1,4 +1,4 @@
 ironic-lib @ git+https://github.com/openshift/openstack-ironic-lib@96ac462d0c3d53c70256cb048e42c317cc41b682
-ironic-python-agent @ git+https://github.com/openshift/openstack-ironic-python-agent@17814b103926d1b5ead634897515062bf80bb218
+ironic-python-agent @ git+https://github.com/openshift/openstack-ironic-python-agent@ab8cc7e8ced89f0936e2975a54e9b8c8aaae98ec
 
 # DEPENDENCIES


### PR DESCRIPTION
Rebases onto `release-4.18` after #313 (OCPBUGS-88475, CVE-2026-43003) merged, and corrects the `requirements.cachito` pin for `ironic-python-agent` from `dd43c074` (PR-head SHA of #198, taken before the current base tip) to `ab8cc7e8` (the real merge commit of #198), picking up the CVE-2026-66138 fix (OCPBUGS-99888).

`ab8cc7e8` is a merge commit whose other parent is `17814b10` -- the exact commit #313 already pinned to -- so this does not reopen or duplicate OCPBUGS-88475 / CVE-2026-43003, already fixed by #313.

Related: OCPBUGS-99888
